### PR TITLE
修复音频重采样后爆音问题

### DIFF
--- a/resample.py
+++ b/resample.py
@@ -20,6 +20,7 @@ def process(item):
         if peak > 1.0:
             wav = 0.98 * wav / peak
         wav2 = librosa.resample(wav, orig_sr=sr, target_sr=args.sr2)
+        wav2 /= max(wav2.max(), -wav2.min())
         save_name = wav_name
         save_path2 = os.path.join(args.out_dir2, speaker, save_name)
         wavfile.write(


### PR DESCRIPTION
librosa在重采样后会出现音频峰值大于1的情况，在tensorboard里预览音频的时候会发现爆音问题相当明显。建议在重采样后对音频再进行一次标准化，经本地试验，通过该方法问题可以得到解决。