### PR TITLE
在 config.json 中添加可配置项，用于清除过期 checkpoints，防止磁盘占用过大

### DIFF
--- a/preprocess_flist_config.py
+++ b/preprocess_flist_config.py
@@ -24,7 +24,8 @@ config_template = {
     "c_kl": 1.0,
     "use_sr": True,
     "max_speclen": 384,
-    "port": "8001"
+    "port": "8001",
+    "keep_ckpts": 5,  # Number of ckpts to keep, if 0, keep all
   },
   "data": {
     "training_files":"filelists/train.txt",

--- a/train.py
+++ b/train.py
@@ -223,6 +223,11 @@ def train_and_evaluate(rank, epoch, hps, nets, optims, schedulers, scaler, loade
                                       os.path.join(hps.model_dir, "G_{}.pth".format(global_step)))
                 utils.save_checkpoint(net_d, optim_d, hps.train.learning_rate, epoch,
                                       os.path.join(hps.model_dir, "D_{}.pth".format(global_step)))
+
+                if hps.train.keep_ckpts > 0:
+                    utils.clean_checkpoints(path_to_models='logs/32k/', n_ckpts_to_keep=hps.train.keep_ckpts,
+                                            sort_by_time=True)
+
         global_step += 1
 
     if rank == 0:

--- a/utils.py
+++ b/utils.py
@@ -128,9 +128,9 @@ def save_checkpoint(model, optimizer, learning_rate, iteration, checkpoint_path)
               'iteration': iteration,
               'optimizer': optimizer.state_dict(),
               'learning_rate': learning_rate}, checkpoint_path)
-  clean_ckpt = False
-  if clean_ckpt:
-    clean_checkpoints(path_to_models='logs/32k/', n_ckpts_to_keep=3, sort_by_time=True)
+  # clean_ckpt = False
+  # if clean_ckpt:
+  #   clean_checkpoints(path_to_models='logs/32k/', n_ckpts_to_keep=3, sort_by_time=True)
 
 def clean_checkpoints(path_to_models='logs/48k/', n_ckpts_to_keep=2, sort_by_time=True):
   """Freeing up space by deleting saved ckpts


### PR DESCRIPTION
配置项添加在[preprocess_flist_config.py](https://github.com/CyborgParadisum/so-vits-svc/compare/32k...SuCicada:so-vits-svc:32k?expand=1#diff-58700e1e48f6b3abc579a057bf49d00ed26e94b8ad501bc5b409500551ef7d96)中，在生成`congfig.json`文件的时候会附带进去。

添加配置字段：
- 名称：`train.keep_ckpts`
- 类型：`int`
- 含义：为最多保留的`ckpts`文件数量，`ckpts`即 `G_*.pth` 和 `D_*.pth` 文件，排除 `G_0.pth` 和 `D_0.pth`。如果为`0`则不做删除处理，保留所有训练过程中产生的检查点文件（注意，磁盘占用相当大）
- 默认值：`5`  （因为考虑到过大的磁盘占用会导致机器故障）

清理ckpts的逻辑参见：https://github.com/innnky/so-vits-svc/issues/20

相关讨论：https://github.com/innnky/so-vits-svc/issues/35
https://github.com/CyborgParadisum/so-vits-svc/pull/2